### PR TITLE
fix: deprectate enqueCommand in favor of enqueueCommand

### DIFF
--- a/packages/core/src/bridge.js
+++ b/packages/core/src/bridge.js
@@ -96,15 +96,21 @@ export const getConfig = function () {
   return $config;
 };
 
+
 /**
  * Enqueues a bridge command due to delayed instance of bridge and premature execution of commands.
  *
  * @param {string} command - The command to be enqueued.
  * @param {any[]} parameters - The parameters to be enqueued.
  */
-export const enqueCommand = function (command, parameters) {
+export const enqueueCommand = function (command, parameters) {
   $queueCommands.push({ command, parameters });
 };
+
+/**
+ * @deprecated Use {@link enqueueCommand} instead
+ */
+export const enqueCommand = enqueueCommand;
 
 /**
  * Constants object containing various constant values.

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -1,1 +1,1 @@
-export { $bridge, Bridge, enqueCommand, startApp, getConfig } from './bridge';
+export { $bridge, Bridge, enqueCommand, enqueueCommand, startApp, getConfig } from './bridge';

--- a/packages/element-controller/src/ElementController.js
+++ b/packages/element-controller/src/ElementController.js
@@ -1,4 +1,4 @@
-import { $bridge, enqueCommand } from '@open-cells/core';
+import { $bridge, enqueueCommand } from '@open-cells/core';
 
 function __callBridge(...args) {
   const [command, ...parameters] = args;
@@ -14,7 +14,7 @@ function __callBridge(...args) {
     return result;
   }
 
-  enqueCommand(command, parameters);
+  enqueueCommand(command, parameters);
   return result;
 }
 


### PR DESCRIPTION
Correct the typo in function enqueCommand. marked as deprecated to avoid problems. It could be removed in next mayor version or final release.